### PR TITLE
main.go: Increase the button assertion time

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,15 +60,15 @@ func main() {
 	switch {
 	case *powerOnFlag:
 		log.Println("powering on")
-		pressButton(gpio, cfg.CommandIDs.Power, 100*time.Millisecond)
+		pressButton(gpio, cfg.CommandIDs.Power, 1*time.Second)
 		os.Exit(0)
 	case *powerOffFlag:
 		log.Println("powering off")
-		pressButton(gpio, cfg.CommandIDs.Power, 5*time.Second)
+		pressButton(gpio, cfg.CommandIDs.Power, 6*time.Second)
 		os.Exit(0)
 	case *resetFlag:
 		log.Println("resetting")
-		pressButton(gpio, cfg.CommandIDs.Reset, 100*time.Millisecond)
+		pressButton(gpio, cfg.CommandIDs.Reset, 1*time.Second)
 		os.Exit(0)
 	case *toggleRelayFlag:
 		log.Println("toggling relay")


### PR DESCRIPTION
For some platforms these assertion pulses may be too short. Increase
them to at least 1 second. The power button override 5s may be too
short as well, increase to 6s.

Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>